### PR TITLE
fix: lock pnpm to v6

### DIFF
--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -19,7 +19,7 @@ export const writeNpmrc = async () => {
 export const runInstall = async (cwd: string = process.cwd()) => {
   console.info('run install...');
   if (!(await canUsePnpm())) {
-    await execaWithStreamLog('npm', ['install', '-g', 'pnpm'], { cwd });
+    await execaWithStreamLog('npm', ['install', '-g', 'pnpm@6'], { cwd });
   }
   if (!(await canUseYarn())) {
     await execaWithStreamLog('npm', ['install', '-g', 'yarn'], { cwd });


### PR DESCRIPTION
pnpm v7 breaks the release action

https://github.com/modern-js-dev/modern.js/runs/6308268617?check_suite_focus=true