### PR TITLE
feat: print tags and package name in `listTagsAndGetPackages` when error occurs

### DIFF
--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -55,7 +55,7 @@ export async function getPackageManager(cwd = process.cwd()) {
  */
 export function getPackageInfo(packageName: string) {
   if (!packageName) {
-    throw new Error('package is not exisit');
+    throw new Error(`package ${packageName} not found`);
   }
   const splitAt = packageName.split('@');
   let pkgVersion = 'latest';

--- a/src/utils/release.ts
+++ b/src/utils/release.ts
@@ -86,6 +86,8 @@ export const runRelease = async (
 
 export const listTagsAndGetPackages = async () => {
   const { stdout } = await execa('git', ['--no-pager', 'tag', '-l']);
+  console.info('[Tags]: list tags:');
+  console.info(stdout);
   const result: Record<string, string> = {};
   stdout.split('\n').forEach(info => {
     const { name, version } = getPackageInfo(info);
@@ -93,8 +95,6 @@ export const listTagsAndGetPackages = async () => {
       result[name] = version;
     }
   });
-  console.info('[Tags]: list tags:');
-  console.info(stdout);
   console.info('[Packages]:');
   console.info(JSON.stringify(result));
   return `Packages: ${JSON.stringify(result, null, 2)}`;


### PR DESCRIPTION
```
Error: package is not exisit
    at getPackageInfo (/home/runner/work/_actions/web-infra-dev/actions/v2/dist/index.js:175745:11)
    at /home/runner/work/_actions/web-infra-dev/actions/v2/dist/index.js:175829:48
    at Array.forEach (<anonymous>)
    at listTagsAndGetPackages (/home/runner/work/_actions/web-infra-dev/actions/v2/dist/index.js:175828:22)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async release (/home/runner/work/_actions/web-infra-dev/actions/v2/dist/index.js:175[91](https://github.com/web-infra-dev/rspack/actions/runs/4674142940/jobs/8278221679#step:9:92)6:19)
    at async /home/runner/work/_actions/web-infra-dev/actions/v2/dist/index.js:177471:7
```

https://github.com/web-infra-dev/rspack/actions/runs/4674142940/jobs/8278221679